### PR TITLE
fix: sounds reloading on every config change

### DIFF
--- a/src/main/java/com/soundswapper/SoundSwapperPlugin.java
+++ b/src/main/java/com/soundswapper/SoundSwapperPlugin.java
@@ -41,6 +41,8 @@ public class SoundSwapperPlugin extends Plugin
 
 	private static final File SOUND_DIR = new File(RuneLite.RUNELITE_DIR, "SoundSwapper");
 
+	private static final String CONFIG_GROUP = "soundswapper";
+
 	@Provides
 	SoundSwapperConfig provideConfig(ConfigManager configManager)
 	{
@@ -57,6 +59,10 @@ public class SoundSwapperPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
+		if (!CONFIG_GROUP.equals(event.getGroup())) {
+			return;
+		}
+
 		updateList();
 	}
 


### PR DESCRIPTION
The `onConfigChanged` function is called any time any config for any
plugin is changed, causing the `updateList` function to be called a lot
more than it needed to be.
This change returns early if the config change is not relevant to the
Sound Swapper plugin.

Fixes #7

# How was this tested
I added a `log.debug` to the top of the `updateList` function, ran runelite in `--debug` mode, commented out the `return` I added in this PR, then changed config values in unrelated plugins and observed the `log.debug` firing.
I then reverted the comment on the `return`, changed config values in unrelated plugins again, and confirmed I did not see the `log.debug` firing.
I also confirmed the `log.debug` fired when changing this plugin's config values.