### PR TITLE
Fix memory leak by closing Clips after they finish

### DIFF
--- a/src/main/java/com/soundswapper/SoundSwapperPlugin.java
+++ b/src/main/java/com/soundswapper/SoundSwapperPlugin.java
@@ -49,6 +49,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 @Slf4j
 @PluginDescriptor(
@@ -364,6 +365,13 @@ public class SoundSwapperPlugin extends Plugin
         try
         {
             Clip clip = AudioSystem.getClip();
+            CountDownLatch latch = new CountDownLatch(1);
+            clip.addLineListener(event -> {
+                if (event.getType() == LineEvent.Type.STOP) {
+                    latch.countDown(); // Signal that playback has finished
+                    clip.close();
+                }
+            });
             clip.open(sound.getFormat(), sound.getBytes(), 0, sound.getNumBytes());
 
             if (volume != -1)
@@ -377,7 +385,18 @@ public class SoundSwapperPlugin extends Plugin
             }
 
             clip.setFramePosition(0);
-            clip.start();
+            // Start playback in a separate thread
+            new Thread(clip::start).start();
+
+            // Wait for playback to finish without blocking the main thread
+            new Thread(() -> {
+                try {
+                    latch.await(); // Wait until the clip finishes playing
+                } catch (InterruptedException e) {
+                    log.warn("Failed to play custom sound");
+                    Thread.currentThread().interrupt();
+                }
+            }).start();
         } catch (LineUnavailableException e)
         {
             log.warn("Failed to play custom sound");

--- a/src/main/java/com/soundswapper/SoundSwapperPlugin.java
+++ b/src/main/java/com/soundswapper/SoundSwapperPlugin.java
@@ -49,7 +49,6 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 @Slf4j
 @PluginDescriptor(
@@ -365,10 +364,8 @@ public class SoundSwapperPlugin extends Plugin
         try
         {
             Clip clip = AudioSystem.getClip();
-            CountDownLatch latch = new CountDownLatch(1);
             clip.addLineListener(event -> {
                 if (event.getType() == LineEvent.Type.STOP) {
-                    latch.countDown(); // Signal that playback has finished
                     clip.close();
                 }
             });
@@ -385,18 +382,7 @@ public class SoundSwapperPlugin extends Plugin
             }
 
             clip.setFramePosition(0);
-            // Start playback in a separate thread
-            new Thread(clip::start).start();
-
-            // Wait for playback to finish without blocking the main thread
-            new Thread(() -> {
-                try {
-                    latch.await(); // Wait until the clip finishes playing
-                } catch (InterruptedException e) {
-                    log.warn("Failed to play custom sound");
-                    Thread.currentThread().interrupt();
-                }
-            }).start();
+            clip.start();
         } catch (LineUnavailableException e)
         {
             log.warn("Failed to play custom sound");


### PR DESCRIPTION
This change fixes a memory leak caused by leaving Clip objects open. This uses up system resources and leaves a daemon thread active for each Clip instance created that never gets released.

From my testing using prayer-flicking on a prayer with a swapped sound, I can see that no longer are the number of active threads and memory usage growing indefinitely.

Addresses #22