### PR TITLE
Fix blacklisting area sounds with checking the correct list

### DIFF
--- a/src/main/java/com/soundswapper/SoundSwapperPlugin.java
+++ b/src/main/java/com/soundswapper/SoundSwapperPlugin.java
@@ -263,7 +263,7 @@ public class SoundSwapperPlugin extends Plugin
             }
         }
 
-        if (config.consumeAreaSounds() || blacklistedSounds.contains(soundId))
+        if (config.consumeAreaSounds() || blacklistedAreaSounds.contains(soundId))
         {
             if (!whitelistedAreaSounds.isEmpty() && whitelistedAreaSounds.contains(soundId))
             {


### PR DESCRIPTION
Fixes blacklisting area sounds which previously was done by checking for the sound in the list of blacklisted sound effects instead of blacklisted area sounds.