### PR TITLE
version: 2.1.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@petertalbanese @damencs

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # Sound Swapper
-Allows the user to replace any sound effect.
+Allows the user to replace any sound effect. (Note: Specific regions may be blocked to align with Jagex Plugin Hub TOS, e.g. Yama, Theatre of Blood, etc.)
 
 To replace a sound, add its ID to the list in the plugin menu, then place a .wav file with the same name in the
 SoundSwapper folder in your root RuneLite folder. The plugin will grab the sound and use it instead!
 
 E.g. *157,205,550* -> place *157.wav*, *205.wav*, and *550.wav* in the SoundSwapper folder in your RuneLite folder.
 
-To find Sound IDs, you can check https://oldschool.runescape.wiki/w/List_of_in-game_sound_IDs or use the Visual Sounds
-Plugin on the hub.
+To find Sound IDs, you can check https://oldschool.runescape.wiki/w/List_of_in-game_sound_IDs or use the Visual Sounds Plugin on the hub. Additionally, you may use the "Debug Sounds Effects" overlay to identify what sounds are playing.
 
-If you experience any issues or have any concerns, please reach out to Pete OR Damen via a GitHub Issue or by Discord Messaging directly ("Cyber#4309" OR "damen") OR via the Runelite Discord by mentioning @Paperman AND/OR @Damen.
-
-You can also receive assistance for any plugin that Damen manages on the plugin hub in the following **Discord**: https://discord.gg/F2mfSvcnaj - This Discord will cover FAQ, Known Issues, and Feature Requests.
+If you experience any issues or have any concerns, please reach out to *Pete* / *Damen* via a GitHub Issue OR by using the RuneLite Discord/Plugin Hub Discord (https://discord.gg/F2mfSvcnaj) by mentioning *@Paperman* / *@Damen*.
 
 # Native Sound ID Swaps
 In order to replace one native sound ID with another native sound ID, the Native Sound ID section can be enabled and populated. 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -5,4 +5,4 @@ description=Allows the user to replace any sound named in the wiki sounds list h
 tags=Sound,Swapper,SoundSwapper,Pete,Damen,Replace,Area,Effect
 plugins=com.soundswapper.SoundSwapperPlugin
 build=standard
-version=2.0.0
+version=2.1.0

--- a/src/main/java/com/soundswapper/SoundEffectOverlay.java
+++ b/src/main/java/com/soundswapper/SoundEffectOverlay.java
@@ -51,12 +51,14 @@ class SoundEffectOverlay extends OverlayPanel
     private final static Color COLOR_CUSTOM = Color.PINK;
     private final static Color COLOR_BLACKLISTED = Color.ORANGE;
     private final static Color COLOR_WHITELISTED = Color.WHITE;
+    private final static Color COLOR_BLOCKED_REGION = Color.RED;
 
     public static final String ALLOWED = "Allowed";
     public static final String BLACKLISTED = "Blacklisted";
     public static final String CONSUMED = "Consumed";
     public static final String CUSTOM = "Custom";
     public static final String WHITELISTED = "Whitelisted";
+    public static final String BLOCKED_REGION = "Blocked Region";
 
     private final Client client;
     private SoundSwapperPlugin plugin;
@@ -125,8 +127,16 @@ class SoundEffectOverlay extends OverlayPanel
 
         if (plugin.customSounds.containsKey(soundId))
         {
-            action = CUSTOM;
-            actionColor = COLOR_CUSTOM;
+            if (BlockedRegions.inBlockedRegion(client))
+            {
+                action = BLOCKED_REGION;
+                actionColor = COLOR_BLOCKED_REGION;
+            }
+            else
+            {
+                action = CUSTOM;
+                actionColor = COLOR_CUSTOM;
+            }
         }
 
         panelComponent.getChildren().add(LineComponent.builder()
@@ -192,8 +202,16 @@ class SoundEffectOverlay extends OverlayPanel
 
         if (plugin.customAreaSounds.containsKey(soundId))
         {
-            action = CUSTOM;
-            actionColor = COLOR_CUSTOM;
+            if (BlockedRegions.inBlockedRegion(client))
+            {
+                action = BLOCKED_REGION;
+                actionColor = COLOR_BLOCKED_REGION;
+            }
+            else
+            {
+                action = CUSTOM;
+                actionColor = COLOR_CUSTOM;
+            }
         }
 
         panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/com/soundswapper/SoundSwapperConfig.java
+++ b/src/main/java/com/soundswapper/SoundSwapperConfig.java
@@ -225,16 +225,6 @@ public interface SoundSwapperConfig extends Config
     default boolean consumeAmbientSounds() { return false; }
 
     @ConfigItem(
-            keyName = "debugSoundEffects",
-            name = "Debug Sounds Effects",
-            description = "Display the sound effects that play (max 10 lines displayed)<br><br>" +
-                    "White: Sound Effect (G)<br>" +
-                    "Yellow: Area Sound Effect (A)<br>" +
-                    "Gray: Silent Area Sound Effect (SA)",
-            position = 98
-    )
-    default boolean debugSoundEffects() { return false; }
-    @ConfigItem(
             keyName = "nativeSoundIDSwapEnable",
             name = "Enable Native ID Swaps",
             description = "Enables direct replacements of native Sound IDs with another native Sound ID",
@@ -265,4 +255,15 @@ public interface SoundSwapperConfig extends Config
     {
         return "";
     }
+
+    @ConfigItem(
+            keyName = "debugSoundEffects",
+            name = "Debug Sounds Effects",
+            description = "Display the sound effects that play (max 10 lines displayed)<br><br>" +
+                    "White: Sound Effect (G)<br>" +
+                    "Yellow: Area Sound Effect (A)<br>" +
+                    "Gray: Silent Area Sound Effect (SA)",
+            position = 98
+    )
+    default boolean debugSoundEffects() { return false; }
 }

--- a/src/main/java/com/soundswapper/SoundSwapperPlugin.java
+++ b/src/main/java/com/soundswapper/SoundSwapperPlugin.java
@@ -27,15 +27,15 @@ package com.soundswapper;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.Preferences;
-import net.runelite.api.SoundEffectVolume;
+import net.runelite.api.*;
+import net.runelite.api.events.AmbientSoundEffectCreated;
 import net.runelite.api.events.AreaSoundEffectPlayed;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.SoundEffectPlayed;
 import net.runelite.client.RuneLite;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -57,7 +57,8 @@ import java.util.List;
         name = "Sound Swapper",
         description = "Allows the user to replace any sound effect.<br><br>" +
                 "To replace a sound, add its ID to the list in the plugin menu, then place a .wav file with the same name in your root<br>" +
-                "RuneLite folder. The plugin will grab the sound and use it instead!"
+                "RuneLite folder. The plugin will grab the sound and use it instead!<br><br>" +
+                "* Note: Some regions may block sound swapping per Jagex TOS."
 )
 public class SoundSwapperPlugin extends Plugin
 {
@@ -79,6 +80,9 @@ public class SoundSwapperPlugin extends Plugin
     @Inject
     private SoundEffectOverlay soundEffectOverlay;
 
+    @Inject
+    public ChatMessageManager chatMessageManager;
+
     public HashMap<Integer, Sound> customSounds = new HashMap<>();
 
     public HashMap<Integer, Sound> customAreaSounds = new HashMap<>();
@@ -89,6 +93,8 @@ public class SoundSwapperPlugin extends Plugin
     public List<Integer> blacklistedAreaSounds = new ArrayList<>();
     public List<Integer> nativeSoundIDsToSwap = new ArrayList<>();
     public List<Integer> nativeSoundIDReplacements = new ArrayList<>();
+
+    public HashMap<SoundType, String> failureMessages = new HashMap<>();
 
     private static final File SOUND_DIR = new File(RuneLite.RUNELITE_DIR, "SoundSwapper");
 
@@ -139,15 +145,29 @@ public class SoundSwapperPlugin extends Plugin
 
         switch (event.getKey())
         {
+            case "soundEffects":
+            {
+                if (event.getNewValue().equals("true"))
+                    updateSoundList(SoundType.SOUND, customSounds, config.customSounds());
+                break;
+            }
+
             case "customSounds":
             {
-                updateSoundList(customSounds, event.getNewValue());
+                updateSoundList(SoundType.SOUND, customSounds, event.getNewValue());
+                break;
+            }
+
+            case "areaSoundEffects":
+            {
+                if (event.getNewValue().equals("true"))
+                    updateSoundList(SoundType.AREA, customAreaSounds, config.customAreaSounds());
                 break;
             }
 
             case "customAreaSounds":
             {
-                updateSoundList(customAreaSounds, event.getNewValue());
+                updateSoundList(SoundType.AREA, customAreaSounds, event.getNewValue());
                 break;
             }
 
@@ -175,7 +195,8 @@ public class SoundSwapperPlugin extends Plugin
                 break;
             }
 
-            case "consumeAmbientSounds": {
+            case "consumeAmbientSounds":
+            {
                 clientThread.invokeLater(() ->
                 {
                     // Reload the scene to reapply ambient sounds
@@ -187,13 +208,15 @@ public class SoundSwapperPlugin extends Plugin
                 break;
             }
 
-            case "nativeSoundIDsToReplace": {
-                nativeSoundIDsToSwap = getIds( event.getNewValue() );
+            case "nativeSoundIDsToReplace":
+            {
+                nativeSoundIDsToSwap = getIds(event.getNewValue());
                 break;
             }
 
-            case "nativeSoundIDReplacements": {
-                nativeSoundIDReplacements = getIds( event.getNewValue() );
+            case "nativeSoundIDReplacements":
+            {
+                nativeSoundIDReplacements = getIds(event.getNewValue());
                 break;
             }
         }
@@ -205,12 +228,12 @@ public class SoundSwapperPlugin extends Plugin
     {
         if (!config.customSounds().isEmpty())
         {
-            updateSoundList(customSounds, config.customSounds());
+            updateSoundList(SoundType.SOUND, customSounds, config.customSounds());
         }
 
         if (!config.customAreaSounds().isEmpty())
         {
-            updateSoundList(customAreaSounds, config.customAreaSounds());
+            updateSoundList(SoundType.AREA, customAreaSounds, config.customAreaSounds());
         }
 
         if (!config.whitelistSounds().isEmpty())
@@ -247,14 +270,28 @@ public class SoundSwapperPlugin extends Plugin
     @Subscribe
     public void onSoundEffectPlayed(SoundEffectPlayed event)
     {
+        int soundId = event.getSoundId();
+
+        if (config.consumeSoundEffects() || blacklistedSounds.contains(soundId))
+        {
+            if (!whitelistedSounds.isEmpty() && whitelistedSounds.contains(soundId))
+            {
+                log.debug("whitelisted other sound effect passed: {}", soundId);
+                return;
+            }
+
+            log.debug("consumed other sound effect: {}", soundId);
+            event.consume();
+            return;
+        }
+
         if (BlockedRegions.inBlockedRegion(client))
         {
             return;
         }
 
-        int soundId = event.getSoundId();
-
-        if (config.nativeSoundIDSwapEnable()) {
+        if (config.nativeSoundIDSwapEnable())
+        {
             if (nativeSoundIDsToSwap.contains(soundId))
             {
                 int idx = nativeSoundIDsToSwap.indexOf(soundId);
@@ -287,29 +324,30 @@ public class SoundSwapperPlugin extends Plugin
                 return;
             }
         }
-
-        if (config.consumeSoundEffects() || blacklistedSounds.contains(soundId))
-        {
-            if (!whitelistedSounds.isEmpty() && whitelistedSounds.contains(soundId))
-            {
-                log.debug("whitelisted other sound effect passed: {}", soundId);
-                return;
-            }
-
-            log.debug("consumed other sound effect: {}", soundId);
-            event.consume();
-        }
     }
 
     @Subscribe
     public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed event)
     {
+        int soundId = event.getSoundId();
+
+        if (config.consumeAreaSounds() || blacklistedAreaSounds.contains(soundId))
+        {
+            if (!whitelistedAreaSounds.isEmpty() && whitelistedAreaSounds.contains(soundId))
+            {
+                log.debug("whitelisted area sound effect passed: {}", soundId);
+                return;
+            }
+
+            log.debug("consumed area sound effect: {}", soundId);
+            event.consume();
+            return;
+        }
+
         if (BlockedRegions.inBlockedRegion(client))
         {
             return;
         }
-
-        int soundId = event.getSoundId();
 
         if (config.nativeSoundIDSwapEnable()) {
             if (nativeSoundIDsToSwap.contains(soundId))
@@ -344,17 +382,14 @@ public class SoundSwapperPlugin extends Plugin
                 return;
             }
         }
+    }
 
-        if (config.consumeAreaSounds() || blacklistedAreaSounds.contains(soundId))
+    @Subscribe
+    public void onAmbientSoundEffectCreated(AmbientSoundEffectCreated event)
+    {
+        if (config.consumeAmbientSounds())
         {
-            if (!whitelistedAreaSounds.isEmpty() && whitelistedAreaSounds.contains(soundId))
-            {
-                log.debug("whitelisted area sound effect passed: {}", soundId);
-                return;
-            }
-
-            log.debug("consumed area sound effect: {}", soundId);
-            event.consume();
+            client.getAmbientSoundEffects().clear();
         }
     }
 
@@ -368,10 +403,13 @@ public class SoundSwapperPlugin extends Plugin
             {
                 client.getAmbientSoundEffects().clear();
             }
+
+            // Notify the user on login for sound failures that are determined on Startup
+            queueFailureMessages();
         }
     }
 
-    private boolean tryLoadSound(HashMap<Integer, Sound> sounds, String sound_name, Integer sound_id)
+    private boolean tryLoadSound(SoundType type, HashMap<Integer, Sound> sounds, String sound_name, Integer sound_id)
     {
         File sound_file = new File(SOUND_DIR, sound_name + ".wav");
 
@@ -391,30 +429,61 @@ public class SoundSwapperPlugin extends Plugin
 
                 return true;
             }
-            catch (UnsupportedAudioFileException | IOException e)
+            catch (UnsupportedAudioFileException e)
             {
-                log.warn("Unable to load custom sound " + sound_name, e);
+                failureMessages.put(type, sound_name + ": unsupported audio format");
+				log.warn("Unable to load custom sound {}", sound_name, e);
+            }
+            catch (IOException e)
+            {
+                failureMessages.put(type, sound_name + ": IO error");
+				log.warn("Unable to load custom sound {}", sound_name, e);
+            }
+            catch (Exception e)
+            {
+                failureMessages.put(type, sound_name + ": unknown error");
+                log.warn("Unable to load custom sound {}", sound_name, e);
+            }
+        }
+        else
+        {
+            // Attempt a ".wav.wav" fallback for users who put the file type in name
+            File fallback_file = new File(SOUND_DIR, sound_name + ".wav" + ".wav");
+            if (fallback_file.exists())
+            {
+                log.debug("Located fallback file for custom sound {}", sound_name);
+                return tryLoadSound(type, sounds, sound_name + ".wav", sound_id);
+            }
+            else
+            {
+                failureMessages.put(type, sound_name + ": file does not exist");
+                log.warn("Unable to locate file for custom sound {}", sound_name);
             }
         }
 
         return false;
     }
 
-    private void updateSoundList(HashMap<Integer, Sound> sounds, String configText)
+    private void updateSoundList(SoundType type, HashMap<Integer, Sound> sounds, String configText)
     {
         sounds.clear();
+        failureMessages.clear();
 
         for (String s : Text.fromCSV(configText))
         {
             try
             {
                 int id = Integer.parseInt(s);
-                tryLoadSound(sounds, s, id);
+                tryLoadSound(type, sounds, s, id);
+
             } catch (NumberFormatException e)
             {
-                log.warn("Invalid sound ID: {}", s);
+                queueChatMessage("Sound Swapper has been provided with an invalid " + type.getType() + " Id: " + s);
+                log.warn("Invalid {} sound ID: {}", type.getType(), s);
             }
         }
+
+        queueFailureMessages();
     }
 
     private List<Integer> getIds(String configText)
@@ -424,6 +493,7 @@ public class SoundSwapperPlugin extends Plugin
             return List.of();
         }
 
+        boolean shouldNotify = false;
         List<Integer> ids = new ArrayList<>();
         for (String s : Text.fromCSV(configText))
         {
@@ -435,8 +505,12 @@ public class SoundSwapperPlugin extends Plugin
             catch (NumberFormatException e)
             {
                 log.warn("Invalid id when parsing {}: {}", configText, s);
+                shouldNotify = true;
             }
         }
+
+        if (shouldNotify)
+            queueChatMessage("Sound Swapper failed to parse a portion of the recently altered config due to an invalid value: " + configText);
 
         return ids;
     }
@@ -481,6 +555,31 @@ public class SoundSwapperPlugin extends Plugin
         blacklistedAreaSounds = new ArrayList<>();
         nativeSoundIDsToSwap = new ArrayList<>();
         nativeSoundIDReplacements = new ArrayList<>();
+        failureMessages = new HashMap<>();
         soundEffectOverlay.resetLines();
+    }
+
+    public void queueChatMessage(String message)
+    {
+        if (client.getGameState() == GameState.LOGGED_IN)
+        {
+            chatMessageManager.queue(QueuedMessage.builder().type(ChatMessageType.GAMEMESSAGE).value(message).build());
+        }
+    }
+
+    public void queueFailureMessages()
+    {
+        if (failureMessages.isEmpty())
+            return;
+
+        queueChatMessage("Sound Swapper failed to load the following sounds:");
+
+        failureMessages.forEach((type, failure) ->
+        {
+            // e.g. "- Sound Id 2266: file does not exist" or "- Area Sound Id 10236: unsupported audio file format"
+            String message = "- " + type.getType() + " Id " + failure;
+
+            queueChatMessage(message);
+        });
     }
 }

--- a/src/main/java/com/soundswapper/SoundType.java
+++ b/src/main/java/com/soundswapper/SoundType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Damen <https://github.com/damencs>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.soundswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SoundType
+{
+	SOUND("Sound"),
+	AREA("Area Sound");
+
+	private final String type;
+}


### PR DESCRIPTION
- fixes: blacklisted regions superseding consumed/whitelisted sounds
- adds: blacklisted region debug overlay indications
- adds: blacklisted region notices to README and plugin description
- adds: failure messages for file exceptions (unable to locate file, invalid format, etc.)
- adds: additional trigger points for resetting loaded sounds
- adds: "{}.wav.wav" file support (assists with the inquiries where a user names a .wav file with .wav in it)
- adjusts: minor checkstyle and config ordering